### PR TITLE
Fix for permission issue when running apt-get & chmod command as mssql user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,11 @@ RUN npm install
 COPY . /usr/src/app
 
 # Grant permissions for the import-data script to be executable
+USER root
 RUN chmod +x /usr/src/app/import-data.sh
 
 EXPOSE 8080
 
+# Switch back to mssql user and run the entrypoint script
+USER mssql
 CMD /bin/bash ./entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM microsoft/mssql-server-linux:latest
 
+# Switch to root user for access to apt-get install
+USER root
+
 # Install node/npm
 RUN apt-get -y update  && \
         apt-get install -y curl && \
@@ -21,7 +24,6 @@ RUN npm install
 COPY . /usr/src/app
 
 # Grant permissions for the import-data script to be executable
-USER root
 RUN chmod +x /usr/src/app/import-data.sh
 
 EXPOSE 8080

--- a/README.md
+++ b/README.md
@@ -69,9 +69,10 @@ The Dockerfile can define a base image as the first layer.  In this case, the Do
 FROM microsoft/mssql-server-linux:latest
 ```
 
-This RUN command will update all the installed packages in the image, install the curl utility if it is not already there and then install node.
+This RUN command will update all the installed packages in the image, install the curl utility if it is not already there and then install node.  This command must be run with sudo privileges so the user is switched to root.
 
 ```Dockerfile
+USER root
 RUN apt-get -y update  && \
         apt-get install -y curl && \
         curl -sL https://deb.nodesource.com/setup_6.x | bash - && \
@@ -107,9 +108,8 @@ Then all the source code from the project is copied into the container image in 
 COPY . /usr/src/app
 ```
 
-In order for the import-data.sh script to be executable you need to run the chmod command as root to add +x (execute) to the file.
+In order for the import-data.sh script to be executable you need to run the chmod command to add +x (execute) to the file.
 ```Dockerfile
-USER root
 RUN chmod +x /usr/src/app/import-data.sh
 ```
 

--- a/README.md
+++ b/README.md
@@ -65,13 +65,13 @@ The Dockerfile defines how the image will be built.  Each of the commands in the
 
 The Dockerfile can define a base image as the first layer.  In this case, the Dockerfile uses the official Microsoft SQL Server Linux image that can be found on [Docker Hub](http://hub.docker.com/r/microsoft/mssql-server-linux).  The Dockerfile will pull the image with the 'latest' tag.  This image requires two environment variables to be passed to it at run time - `ACCEPT_EULA` and `SA_PASSWORD`.  The Microsoft SQL Server Linux inmage is in turn based on the official Ubuntu Linux image `Ubuntu:16.04`.
 
-```
+```Dockerfile
 FROM microsoft/mssql-server-linux:latest
 ```
 
 This RUN command will update all the installed packages in the image, install the curl utility if it is not already there and then install node.
 
-``` 
+```Dockerfile
 RUN apt-get -y update  && \
         apt-get install -y curl && \
         curl -sL https://deb.nodesource.com/setup_6.x | bash - && \
@@ -84,41 +84,43 @@ This installs the tedious driver for SQL Server which allows node applications t
 
 [Source Code](https://github.com/tediousjs/tedious)
 
-```
+```Dockerfile
 RUN npm install tedious
 ```
 
 This RUN command creates a new directory _inside_ the container at /usr/src/app and then sets the working directory to that directory.
 
-``` 
+```Dockerfile
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 ```
 
 Then this command copies the package.json file from the source code in this project to the /usr/src/app directory _inside_ the container.  The RUN command npm install will install all the dependencies defined in the package.json file.
 
-```
+```Dockerfile
 COPY package.json /usr/src/app/
 RUN npm install
 ```
 
 Then all the source code from the project is copied into the container image in the /usr/src/app directory.
-```
+```Dockerfile
 COPY . /usr/src/app
 ```
 
-In order for the import-data.sh script to be executable you need to run the chmod command to add +x (execute) to the file.
-```
+In order for the import-data.sh script to be executable you need to run the chmod command as root to add +x (execute) to the file.
+```Dockerfile
+USER root
 RUN chmod +x /usr/src/app/import-data.sh
 ```
 
 The EXPOSE command defines which port the application will be accessible at from outside the container.
-```
+```Dockerfile
 EXPOSE 8080
 ```
 
-Lastly, the CMD command defines what will be executed when the container starts.  In this case, it will execute the entrypoint.sh script contained in the source code for this project.  The souce code including the entrypoint.sh is contained in the /usr/src/app directory which has also been made the working directory by the commands above.
-```
+Lastly, the CMD command defines what will be executed when the container starts.  In this case, it will execute the entrypoint.sh script contained in the source code for this project.  The souce code including the entrypoint.sh is contained in the /usr/src/app directory which has also been made the working directory by the commands above.  The user is also switched back to the `mssql` user for security reasons.
+```Dockerfile
+USER mssql
 CMD /bin/bash ./entrypoint.sh
 ```
 


### PR DESCRIPTION
### The Problem
The SQL Server Docker image now uses the `mssql` user by default, and no longer runs as `root` user. This was causing the apt-get install command as well as the chmod command in the Dockerfile to fail. Documented in issue #21 , error message for apt-get is: `E: List directory /var/lib/apt/lists/partial is missing. - Acquire (13: Permission denied)`

### The Solution
Switch to `root` user only for the chmod command:
```Dockerfile
USER root
RUN chmod +x /usr/src/app/import-data.sh
```
and switch back to `mssql` user before the `entrypoint.sh` CMD:
```Dockerfile
USER mssql
CMD /bin/bash ./entrypoint.sh
```

#### Commit comment
Add switch to root user in order to chmod the import-data.sh script, and switch back to mssql user prior to running entrypoint.sh script. Add Dockerfile syntax highlighting in README.md for Dockerfile code snippets.
Fix root user issue for apt-get install command